### PR TITLE
The About popup displays #8230 rather than ellipsis

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -36,7 +36,7 @@
     <!-- About -->
 	<string name="menu_about">About</string>
 	<string name="menu_about_ally">About</string>
-	<string name="about_title">About MythTV Android Frontend#8230;</string>
+	<string name="about_title">About MythTV Android Frontend&#8230;</string>
 	<string name="about_url1"><u>https://github.com/MythTV-Clients/MythTV-Android-Frontend</u></string>
 	<string name="about_url2"><u>http://mythtv.org</u></string>
 	<string name="about_url3"><u>http://c9studio.com</u></string>


### PR DESCRIPTION
I know... this is a new low in mentioning the trivial.

When I display the About window/popup, the string:
-  About MythTV Android Frontend#8230

is on the top line.

Adding an ampersand in the about_title string allows the About popup to display what I suspect are the desired horizontal ellipsis.
