### PR TITLE
Add Play Store descriptions to GitHub repository

### DIFF
--- a/playstore/README.md
+++ b/playstore/README.md
@@ -1,0 +1,4 @@
+The contents of this folder are not part of the MythtTV Android Frontend App.
+They contain a copy of the texts of the Google Play Store listing of the
+Application. Tracking the content in GIT makes it easier for translators
+to get notified of changes and update the translations.

--- a/playstore/de-DE/Description.txt
+++ b/playstore/de-DE/Description.txt
@@ -14,11 +14,11 @@ MythMote ist vollständig in die Anwendung integriert. Wenn Du MythMote benutzt,
 
 MythTV Android Frontend ist 100% Open Source Software und unter der GPLv3 lizensiert. Du kannst den Fortschritt der Entwicklung unter https://github.com/MythTV-Clients/MythTV-Android-Frontend (Englisch) verfolgen. Dort findest Du auch die Erklärung der Berechtigungen, die die App erfordert. 
 
-Featurewünsche oder Fehlerreports kannst Du auf dem Issues-Tab des GitHub Repositories erstellen: https://github.com/MythTV-Clients/MythTV-Android-Frontend/issues (Englisch)
+Featurewünsche oder Fehlerreports kannst Du auf dem Issues-Tab des GitHub Repositories erstellen: https://github.com/MythTV-Clients/MythTV-Android-Frontend/issues (Englisch).
 
 Die Anwendung hat zur Zeit noch Beta-Status. Statt ein negatives Feedback zu hinterlassen, erstelle bitte einen Fehlerreport so dass wir uns direkt um das Problem kümmern können.
 
-Benötigst Du Unterstützung mit der App? Die Entwickler können über das GitHub Repository kontaktiert werden. Du findest uns auch im IRC auf dem Freenode Netzwerk in #mythtv-users.
+Benötigst Du Unterstützung mit der App? Die Entwickler können über das GitHub Repository erreicht werden. Du findest uns auch im IRC auf dem Freenode Netzwerk in #mythtv-users.
 
  <b>Betatester gesucht!</b> Falls Du am Betatesten von neuen Versionen vor der offiziellen Veröffentlichung interessiert bist, kannst Du der Beta Testers Google+ Community beitreten: https://plus.google.com/u/0/communities/104432707624078706786
 

--- a/playstore/de-DE/Description.txt
+++ b/playstore/de-DE/Description.txt
@@ -1,0 +1,27 @@
+MythTV Android Frontend ist der erste Android Client, der die Unterstützung des MythTV Entwickler-Teams hat.
+
+Um die App zu benutzen, benötigst Du ein fertig eingerichtetes MythTV Backend in den Versionen v0.25 bis v0.27. Mehr Informationen über MythTV findest Du auf http://mythtv.org .
+
+Achtung: Das Öffnen der Aufnahmeregeln-Seite führt mit MythTV v0.27 zu einem Absturz. Ursache sind Erweiterungen am MythTV Services API. Das Problem ist in der Version 1.20.x behoben, die Betatester bereits nutzen können (siehe "Betatester gesucht" weiter unten).
+
+MythTV Android Frontend benötigt einen externen Videoplayer. Wir haben ausführliche Tests mit VPlayer und DicePlayer durchgeführt. Du kannst aber auch jeden anderen Videoplayer verwenden, der HTTP Live Streams abspielt.
+
+Die Anwendung kann sich Daheim und von Unterwegs mit deinem MythTV Backend verbinden. Daheim sucht die App in deinem Netzwerk nach einem Backend und konfiguriert die Verbindung selbständig. Wenn Du dich mit dem Backend von unterwegs verbinden willst, findest Du die Anleitung zum Einrichten unter https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/Access-MythTV-Master-Backend-via-SSH (Englisch). 
+
+Mit der Anwendung kannst Du auf  deine Aufnahmen zugreifen und sie auf dein Android Smartphone oder Tablet streamen. Dazu wird das in MythTV v0.25 eingeführte MythTV HTTP Live Streaming genutzt. Du kannst die kommenden Aufnahmen, das komplette Fernsehprogramm oder deine Aufnahmeregeln anzeigen. Es ist ebenfalls möglich, die Wiedergabeprofile zu bearbeiten und so die Qualität der gestreamten Aufnahmen an die Netzwerkgeschwindigkeit anpassen.
+
+MythMote ist vollständig in die Anwendung integriert. Wenn Du MythMote benutzt, wird automatisch dein MythTV Frontend gefunden. Wähle einfach das Frontend, vor dem Du sitzt, und bediene es. Wenn Du angerufen wirst, während Du MythMote nutzt, wird die Anrufinformation auf deinem Fernseher angezeigt.
+
+MythTV Android Frontend ist 100% Open Source Software und unter der GPLv3 lizensiert. Du kannst den Fortschritt der Entwicklung unter https://github.com/MythTV-Clients/MythTV-Android-Frontend (Englisch) verfolgen. Dort findest Du auch die Erklärung der Berechtigungen, die die App erfordert. 
+
+Featurewünsche oder Fehlerreports kannst Du auf dem Issues-Tab des GitHub Repositories erstellen: https://github.com/MythTV-Clients/MythTV-Android-Frontend/issues (Englisch)
+
+Die Anwendung hat zur Zeit noch Beta-Status. Statt ein negatives Feedback zu hinterlassen, erstelle bitte einen Fehlerreport so dass wir uns direkt um das Problem kümmern können.
+
+Benötigst Du Unterstützung mit der App? Die Entwickler können über das GitHub Repository kontaktiert werden. Du findest uns auch im IRC auf dem Freenode Netzwerk in #mythtv-users.
+
+ <b>Betatester gesucht!</b> Falls Du am Betatesten von neuen Versionen vor der offiziellen Veröffentlichung interessiert bist, kannst Du der Beta Testers Google+ Community beitreten: https://plus.google.com/u/0/communities/104432707624078706786
+
+<b>Übersetzungen sind willkommen!</b> Falls Du MythTV Android Frontend in deine Sprache übersetzen willst, findest Du hier eine Anleitung: https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/_Translation-Process (Englisch)
+
+Die Bilder und Icons wurden von Jay Purugganan erstellt. Auf seiner Website findest Du mehr seiner exzellenten Arbeit: http://c9studio.com

--- a/playstore/de-DE/Promo_text.txt
+++ b/playstore/de-DE/Promo_text.txt
@@ -1,1 +1,1 @@
-Nutze Deine MythTV Medien von Zuhause oder Unterwegs mit dem MythTV Android Frontend.
+Nutze deine MythTV Medien Daheim oder von Unterwegs mit dem MythTV Android Frontend.

--- a/playstore/de-DE/Promo_text.txt
+++ b/playstore/de-DE/Promo_text.txt
@@ -1,0 +1,1 @@
+Nutze Deine MythTV Medien von Zuhause oder Unterwegs mit dem MythTV Android Frontend.

--- a/playstore/de-DE/Promo_text.txt
+++ b/playstore/de-DE/Promo_text.txt
@@ -1,1 +1,1 @@
-Nutze deine MythTV Medien Daheim oder von Unterwegs mit dem MythTV Android Frontend.
+Nutze deine MythTV Medien Daheim oder Unterwegs mit dem MythTV Android Frontend.

--- a/playstore/de-DE/Recent_changes.txt
+++ b/playstore/de-DE/Recent_changes.txt
@@ -4,13 +4,5 @@ v1.10.1
 ======
 - Fehlerkorrektur für Android 2.x Geräte.
 
-v1.10.0
-======
-- Neue Funktionen zum Abspielen von Aufnahmen.
-- Möglichkeit ergänzt, um mythtranscode auf dem Backend im Hintergrund zu starten und die Aufnahme später anzusehen.
-- Vollständige Unterstützung von mehreren Backends.
-- Konsistenzprüfung der Master Backend Daten.
-- Fehlerkorrekturen.
-
 Die detaillierte Liste der Änderungen seit 1.0.4 ist im Wiki zu finden (Englisch):
 https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/Release-Notes

--- a/playstore/de-DE/Recent_changes.txt
+++ b/playstore/de-DE/Recent_changes.txt
@@ -1,0 +1,16 @@
+Betatester erhalten die aktuelle 1.20.x Version
+
+v1.10.1
+======
+- Fehlerkorrektur für Android 2.x Geräte.
+
+v1.10.0
+======
+- Neue Funktionen zum Abspielen von Aufnahmen.
+- Möglichkeit ergänzt, um mythtranscode auf dem Backend im Hintergrund zu starten und die Aufnahme später anzusehen.
+- Vollständige Unterstützung von mehreren Backends.
+- Konsistenzprüfung der Master Backend Daten.
+- Fehlerkorrekturen.
+
+Die detaillierte Liste der Änderungen seit 1.0.4 ist im Wiki zu finden (Englisch):
+https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/Release-Notes

--- a/playstore/en-US/Description.txt
+++ b/playstore/en-US/Description.txt
@@ -1,0 +1,28 @@
+MythTV Android Frontend is the first Android Client fully endorsed by the core MythTV Development Team.
+
+If you plan to use this application, you are required to have a fully functioning MythTV Backend version v0.25 through v0.27.  If you are interested in learning more about MythTV, check their web site at http://mythtv.org.
+
+Note that in MythTV v0.27, using the Recording Rules screen will cause a crash. This is due enhancements in the MythTV Services API. The solution is available to beta testers in 1.20.x (see: Beta Testers Wanted below.)
+
+An External Video Player is also required.  We have done extensive testing with VPlayer and DicePlayer, but feel free to try any video player capable of playing HTTP Live Streams.
+
+This application can connect to your backend while you are at home or on the go.  At home, the app will scan your network for a MythTV backend and auto-configure its connection.  If you want connect to the backend while away from home, check out our instructions on how to set this up at https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/Access-MythTV-Master-Backend-via-SSH.
+
+With this application you can access your recordings and stream them to your Android phone or tablet via MythTV HTTP Live Streaming, introduced in MythTV v0.25.  You can see what is upcoming or the whole program guide as well as viewing your recording rules.  You can also manage your Playback Profiles so that you can raise or lower the streaming quality of your recordings depending on the speed of your network.
+
+MythMote is fully integrated into the application.  When you use MythMote, your MythTV Frontends will be automatically discovered for you.  Simply select the Frontend you are sitting in front of, and begin navigating.  As an added bonus, if you receive a call while using MythMote, the Caller ID information will be displayed on the TV for you.
+
+MythTV Android Frontend is 100% Open Source software and it is licensed under GPLv3.  You can follow the progress of the application at https://github.com/MythTV-Clients/MythTV-Android-Frontend.  Here you will also see an explanation of the permissions the application requires.
+
+Want to request a feature or ran into an issue, please submit an issue on the Issues tab of our GitHub repository: https://github.com/MythTV-Clients/MythTV-Android-Frontend/issues
+
+The application is currently in beta software.  Before leaving a negative feedback, please consider opening an issue with us first so that we might address the issue directly.
+
+Do you require assistance with the the app?  The developers can be reached at the GitHub repository, or you can find us in IRC on the Freenode network in #mythtv-users.
+
+<b>Beta Testers Wanted!</b> If you are interested in beta testing pre-release versions, please join the beta testers Google+ Community: https://plus.google.com/u/0/communities/104432707624078706786
+ 
+<b>Translations are welcome!</b> If you're interested in translating MythTV Android Frontend for your language, please see: https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/_Translation-Process
+
+The images and icons were developed by Jay Purugganan.  Visit his website to see more of his great work:
+http://c9studio.com

--- a/playstore/en-US/Promo_text.txt
+++ b/playstore/en-US/Promo_text.txt
@@ -1,0 +1,1 @@
+Access your MythTV content at home or on the go with MythTV Android Frontend.

--- a/playstore/en-US/Recent_changes.txt
+++ b/playstore/en-US/Recent_changes.txt
@@ -1,0 +1,16 @@
+Beta testers will get a current 1.20.x version
+
+v1.10.1
+======
+- Bug Fix for android 2.x devices
+
+v1.10.0
+======
+- New methods of playing recordings.
+- New ability to start mythtranscode on the backend in the background and return at a later time to watch a recording
+- Full Multi-Host Support
+- Consistency checks of Master Backend data
+- Bug Fixes
+
+A detailed listing of changes since 1.0.4 can be found on the wiki:
+https://github.com/MythTV-Clients/MythTV-Android-Frontend/wiki/Release-Notes


### PR DESCRIPTION
I've added the en-US and de-DE texts from the Play Store to the repository for easy updating. There is a new folder playstore with a subdirectory for each locale. In the subdirectories there is a text file for each textbox in the Play Store Developer Console.

See issue #240
